### PR TITLE
Update English and Spanish localization for index page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "example_message": "Hello world"
+  "index_title": "Eminence Astro Starter",
+  "index_description": "A modern Astro starter template with quality-of-life features to jumpstart your next web project, deployed on Cloudflare.",
+  "index_h1": "Welcome to Eminence Astro Starter"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "example_message": "Hola mundo"
+  "index_title": "Eminence Astro Starter",
+  "index_description": "Una plantilla moderna de Astro con características de calidad de vida para acelerar tu próximo proyecto web, desplegada en Cloudflare.",
+  "index_h1": "Bienvenido a Eminence Astro Starter"
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,6 @@ import DefaultLayout from "@/layouts/DefaultLayout.astro";
 import { m } from "@/paraglide/messages";
 ---
 
-<DefaultLayout
-  title="Eminence Astro Starter"
-  description="A modern Astro starter template with quality-of-life features to jumpstart your next web project, deployed on Cloudflare"
->
-  <h1>{m.example_message()}</h1>
+<DefaultLayout title={m.index_title()} description={m.index_description()}>
+  <h1>{m.index_h1()}</h1>
 </DefaultLayout>


### PR DESCRIPTION
Enhance the localization for the index page by updating the English and Spanish translations to provide a more accurate title, description, and header. This improves the user experience for both language speakers.